### PR TITLE
Fixed checked property logic in Search view

### DIFF
--- a/src/TechJobs/Views/Search/Index.cshtml
+++ b/src/TechJobs/Views/Search/Index.cshtml
@@ -7,11 +7,23 @@
         @foreach (KeyValuePair<string, string> column in ViewBag.columns)
         {
             <span>
-                <input type="radio"
+                @if(@column.Key == "all")
+                {
+                    <input type="radio"
                        name="searchType"
                        id="@column.Key"
                        value="@column.Key" 
-                       checked="@column.Key == 'all''"/>
+                       checked />
+
+                }
+                else
+                {
+                    <input type="radio"
+                           name="searchType"
+                           id="@column.Key"
+                           value="@column.Key" />
+                }
+                
                 <label for="@column.Key">@column.Value</label>
             </span>
         }


### PR DESCRIPTION
This branch fixes some incorrect code in the Search View. 

**The Problem**

Existing code tries to preselect the 'all' radio button by using the `checked`  HTML property as if it can be set to true or false:

`checked="@column.Key == 'all''"`

This usually outputs something in the HTML like:

`checked="location == 'all''"

One problem here is the two single quotes at the end, which as far as I can tell is just a syntactically-incorrect typo, but the broader issue is that this is not how the checked property works, per [w3 documentation](https://www.w3schools.com/tags/att_input_checked.asp). Essentially, HTML tests for the *presence* of the checked property, rather than evaluating it for true/false. You can see this issue in action in this [demo JSFiddle](https://jsfiddle.net/t82vg0ue/).

**My Fix**

Full disclaimer: I'm not a C# web developer, so there may be a cleaner way to do this, but I just moved this equality logic into an if/else statement that would output an input element with or without the checked property present. Open to ideas on if there's a better way.

**Why This Is Important**

The [first Bonus Mission](https://education.launchcode.org/skills-back-end-csharp/assignments/techjobs-mvc/#bonus-missions) for this assignment tasks students with keeping the previous search field selected -- this incorrect code suggests a way to implement a solution (altering the `checked="@column.Key == 'all''"` equality check) that will never work because HTML is ignoring that entire equality check.
